### PR TITLE
Shippable CI confiuration

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -14,3 +14,7 @@ env:
 build:
   ci:
   - ./gradlew --no-daemon check
+  on_success:
+  - mkdir -p shippable/testresults && cp -R build/test-results/test/*.xml shippable/testresults
+  on_failure:
+  - mkdir -p shippable/testresults && cp -R build/test-results/test/*.xml shippable/testresults

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,16 @@
+language: java
+
+jdk:
+- oraclejdk8
+
+env:
+- GRADLE_VERSION_UNDER_TEST='3.0'
+- GRADLE_VERSION_UNDER_TEST='3.1'
+- GRADLE_VERSION_UNDER_TEST='3.2.1'
+- GRADLE_VERSION_UNDER_TEST='3.3'
+- GRADLE_VERSION_UNDER_TEST='3.4.1'
+- GRADLE_VERSION_UNDER_TEST='3.5'
+
+build:
+  ci:
+  - ./gradlew --no-daemon check

--- a/src/test/java/com/jonaslasauskas/gradle/plugin/capsule/DeclaredAttribute.java
+++ b/src/test/java/com/jonaslasauskas/gradle/plugin/capsule/DeclaredAttribute.java
@@ -83,6 +83,8 @@ import com.jonaslasauskas.gradle.plugin.GradleVersion;
             "  capsuleManifest {",
             "    applicationId = 'test'",
             "    applicationClass = 'test.Main'",
+            "    minJavaVersion = '1.8'",
+            "    javaVersion = '1.8'",
             "    minUpdateVersion['1.8'] = '999'",
             "  }",
             "}")


### PR DESCRIPTION
Provides configuration for [Shippable][1] to run builds.

This is necessary for moving to GitHub as GitLab's CI is not available.

[1]: https://www.shippable.com/